### PR TITLE
Fix the issue that the body message may lost because of body.trim()

### DIFF
--- a/src/main/java/com/gilt/logback/flume/FlumeLogstashV1Appender.java
+++ b/src/main/java/com/gilt/logback/flume/FlumeLogstashV1Appender.java
@@ -15,212 +15,220 @@ import java.util.*;
 
 public class FlumeLogstashV1Appender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
-  protected static final Charset UTF_8 = Charset.forName("UTF-8");
+    protected static final Charset UTF_8 = Charset.forName("UTF-8");
 
-  private FlumeAvroManager flumeManager;
+    private FlumeAvroManager flumeManager;
 
-  private String flumeAgents;
+    private String flumeAgents;
 
-  private String flumeProperties;
+    private String flumeProperties;
 
-  private Long reportingWindow;
+    private Long reportingWindow;
 
-  private Integer batchSize;
+    private Integer batchSize;
 
-  private Integer reporterMaxThreadPoolSize;
+    private Integer reporterMaxThreadPoolSize;
 
-  private Integer reporterMaxQueueSize;
+    private Integer reporterMaxQueueSize;
 
-  private Map<String, String> additionalAvroHeaders;
+    private Map<String, String> additionalAvroHeaders;
 
-  private String application;
+    private String application;
 
-  protected Layout<ILoggingEvent> layout;
+    protected Layout<ILoggingEvent> layout;
 
-  private String hostname;
+    private String hostname;
 
-  private String type;
+    private String type;
 
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  public void setHostname(String hostname) {
-    this.hostname = hostname;
-  }
-
-  public void setApplication(String application) {
-    this.application = application;
-  }
-
-  public void setLayout(Layout<ILoggingEvent> layout) {
-    this.layout = layout;
-  }
-
-  public void setFlumeAgents(String flumeAgents) {
-    this.flumeAgents = flumeAgents;
-  }
-
-  public void setFlumeProperties(String flumeProperties) {
-    this.flumeProperties = flumeProperties;
-  }
-
-  public void setAdditionalAvroHeaders(String additionalHeaders) {
-    this.additionalAvroHeaders = extractProperties(additionalHeaders);
-  }
-
-  public void setBatchSize(String batchSizeStr) {
-    try {
-      this.batchSize = Integer.parseInt(batchSizeStr);
-    } catch (NumberFormatException nfe) {
-      addWarn("Cannot set the batchSize to " + batchSizeStr, nfe);
-    }
-  }
-
-  public void setReportingWindow(String reportingWindowStr) {
-    try {
-      this.reportingWindow = Long.parseLong(reportingWindowStr);
-    } catch (NumberFormatException nfe) {
-      addWarn("Cannot set the reportingWindow to " + reportingWindowStr, nfe);
-    }
-  }
-
-
-  public void setReporterMaxThreadPoolSize(String reporterMaxThreadPoolSizeStr) {
-    try {
-      this.reporterMaxThreadPoolSize = Integer.parseInt(reporterMaxThreadPoolSizeStr);
-    } catch (NumberFormatException nfe) {
-      addWarn("Cannot set the reporterMaxThreadPoolSize to " + reporterMaxThreadPoolSizeStr, nfe);
-    }
-  }
-
-  public void setReporterMaxQueueSize(String reporterMaxQueueSizeStr) {
-    try {
-      this.reporterMaxQueueSize = Integer.parseInt(reporterMaxQueueSizeStr);
-    } catch (NumberFormatException nfe) {
-      addWarn("Cannot set the reporterMaxQueueSize to " + reporterMaxQueueSizeStr, nfe);
-    }
-  }
-
-  @Override
-  public void start() {
-    if (layout == null) {
-      addWarn("Layout was not defined, will only log the message, no stack traces or custom layout");
-    }
-    if (StringUtils.isEmpty(application)) {
-      application = resolveApplication();
+    public void setType(String type) {
+        this.type = type;
     }
 
-    if (StringUtils.isNotEmpty(flumeAgents)) {
-      String[] agentConfigs = flumeAgents.split(",");
+    public void setHostname(String hostname) {
+        this.hostname = hostname;
+    }
 
-      List<RemoteFlumeAgent> agents = new ArrayList<RemoteFlumeAgent>(agentConfigs.length);
-      for (String conf : agentConfigs) {
-        RemoteFlumeAgent agent = RemoteFlumeAgent.fromString(conf.trim());
-        if (agent != null) {
-          agents.add(agent);
+    public void setApplication(String application) {
+        this.application = application;
+    }
+
+    public void setLayout(Layout<ILoggingEvent> layout) {
+        this.layout = layout;
+    }
+
+    public void setFlumeAgents(String flumeAgents) {
+        this.flumeAgents = flumeAgents;
+    }
+
+    public void setFlumeProperties(String flumeProperties) {
+        this.flumeProperties = flumeProperties;
+    }
+
+    public void setAdditionalAvroHeaders(String additionalHeaders) {
+        this.additionalAvroHeaders = extractProperties(additionalHeaders);
+    }
+
+    public void setBatchSize(String batchSizeStr) {
+        try {
+            this.batchSize = Integer.parseInt(batchSizeStr);
+        } catch (NumberFormatException nfe) {
+            addWarn("Cannot set the batchSize to " + batchSizeStr, nfe);
+        }
+    }
+
+    public void setReportingWindow(String reportingWindowStr) {
+        try {
+            this.reportingWindow = Long.parseLong(reportingWindowStr);
+        } catch (NumberFormatException nfe) {
+            addWarn("Cannot set the reportingWindow to " + reportingWindowStr, nfe);
+        }
+    }
+
+
+    public void setReporterMaxThreadPoolSize(String reporterMaxThreadPoolSizeStr) {
+        try {
+            this.reporterMaxThreadPoolSize = Integer.parseInt(reporterMaxThreadPoolSizeStr);
+        } catch (NumberFormatException nfe) {
+            addWarn("Cannot set the reporterMaxThreadPoolSize to " + reporterMaxThreadPoolSizeStr, nfe);
+        }
+    }
+
+    public void setReporterMaxQueueSize(String reporterMaxQueueSizeStr) {
+        try {
+            this.reporterMaxQueueSize = Integer.parseInt(reporterMaxQueueSizeStr);
+        } catch (NumberFormatException nfe) {
+            addWarn("Cannot set the reporterMaxQueueSize to " + reporterMaxQueueSizeStr, nfe);
+        }
+    }
+
+    @Override
+    public void start() {
+        if (layout == null) {
+            addWarn("Layout was not defined, will only log the message, no stack traces or custom layout");
+        }
+        if (StringUtils.isEmpty(application)) {
+            application = resolveApplication();
+        }
+
+        if (StringUtils.isNotEmpty(flumeAgents)) {
+            String[] agentConfigs = flumeAgents.split(",");
+
+            List<RemoteFlumeAgent> agents = new ArrayList<RemoteFlumeAgent>(agentConfigs.length);
+            for (String conf : agentConfigs) {
+                RemoteFlumeAgent agent = RemoteFlumeAgent.fromString(conf.trim());
+                if (agent != null) {
+                    agents.add(agent);
+                } else {
+                    addWarn("Cannot build a Flume agent config for '" + conf + "'");
+                }
+            }
+            Properties overrides = new Properties();
+            overrides.putAll(extractProperties(flumeProperties));
+            flumeManager = FlumeAvroManager.create(agents, overrides,
+                    batchSize, reportingWindow, reporterMaxThreadPoolSize, reporterMaxQueueSize, this);
         } else {
-          addWarn("Cannot build a Flume agent config for '" + conf + "'");
+            addError("Cannot configure a flume agent with an empty configuration");
         }
-      }
-      Properties overrides = new Properties();
-      overrides.putAll(extractProperties(flumeProperties));
-      flumeManager = FlumeAvroManager.create(agents, overrides,
-              batchSize, reportingWindow, reporterMaxThreadPoolSize, reporterMaxQueueSize, this);
-    } else {
-      addError("Cannot configure a flume agent with an empty configuration");
+        super.start();
+
     }
-    super.start();
 
-  }
-
-  private Map<String, String> extractProperties(String propertiesAsString) {
-    final Map<String, String> props = new HashMap<String, String>();
-    if (StringUtils.isNotEmpty(propertiesAsString)) {
-      final String[] segments = propertiesAsString.split(";");
-      for (final String segment : segments) {
-        final String[] pair = segment.split("=");
-        if (pair.length == 2) {
-          final String key = pair[0].trim();
-          final String value = pair[1].trim();
-          if (StringUtils.isNotEmpty(key) && StringUtils.isNotEmpty(value)) {
-            props.put(key, value);
-          } else {
-            addWarn("Empty key or value not accepted: " + segment);
-          }
+    private Map<String, String> extractProperties(String propertiesAsString) {
+        final Map<String, String> props = new HashMap<String, String>();
+        if (StringUtils.isNotEmpty(propertiesAsString)) {
+            final String[] segments = propertiesAsString.split(";");
+            for (final String segment : segments) {
+                final String[] pair = segment.split("=");
+                if (pair.length == 2) {
+                    final String key = pair[0].trim();
+                    final String value = pair[1].trim();
+                    if (StringUtils.isNotEmpty(key) && StringUtils.isNotEmpty(value)) {
+                        props.put(key, value);
+                    } else {
+                        addWarn("Empty key or value not accepted: " + segment);
+                    }
+                } else {
+                    addWarn("Not a valid {key}:{value} format: " + segment);
+                }
+            }
         } else {
-          addWarn("Not a valid {key}:{value} format: " + segment);
+            addInfo("Not overriding any flume agent properties");
         }
-      }
-    } else {
-      addInfo("Not overriding any flume agent properties");
+
+        return props;
     }
 
-    return props;
-  }
-
-  @Override
-  public void stop() {
-    try {
-      if (flumeManager != null) {
-        flumeManager.stop();
-      }
-    } catch (FlumeException fe) {
-      addWarn(fe.getMessage(), fe);
-    }
-  }
-
-  @Override
-  protected void append(ILoggingEvent eventObject) {
-
-    if (flumeManager != null) {
-      try {
-        String body = layout != null ? layout.doLayout(eventObject) : eventObject.getFormattedMessage();
-        Map<String, String> headers = new HashMap<String, String>();
-        if(additionalAvroHeaders != null) {
-          headers.putAll(additionalAvroHeaders);
+    @Override
+    public void stop() {
+        try {
+            if (flumeManager != null) {
+                flumeManager.stop();
+            }
+        } catch (FlumeException fe) {
+            addWarn(fe.getMessage(), fe);
         }
-        headers.putAll(extractHeaders(eventObject));
-
-        Event event = EventBuilder.withBody(body.trim(), UTF_8, headers);
-
-        flumeManager.send(event);
-      } catch (Exception e) {
-        addError(e.getLocalizedMessage(), e);
-      }
     }
 
-  }
+    @Override
+    protected void append(ILoggingEvent eventObject) {
 
-  private Map<String, String> extractHeaders(ILoggingEvent eventObject) {
-    Map<String, String> headers = new HashMap<String, String>(10);
-    headers.put("timestamp", Long.toString(eventObject.getTimeStamp()));
-    headers.put("type", eventObject.getLevel().toString());
-    headers.put("logger", eventObject.getLoggerName());
-    headers.put("message", eventObject.getMessage());
-    headers.put("level", eventObject.getLevel().toString());
-    try {
-      headers.put("host", resolveHostname());
-    } catch (UnknownHostException e) {
-      addWarn(e.getMessage());
+        if (flumeManager != null) {
+            try {
+                String body = layout != null ? layout.doLayout(eventObject) : eventObject.getFormattedMessage();
+                Map<String, String> headers = new HashMap<String, String>();
+                if (additionalAvroHeaders != null) {
+                    headers.putAll(additionalAvroHeaders);
+                }
+                headers.putAll(extractHeaders(eventObject));
+
+
+                //Event event = EventBuilder.withBody(body.trim(), UTF_8, headers);
+        /*
+        FIX-01: trim() will cause the character that not greater than '\u0020' to be trimmed. Not only the whitespace(more details, refer the String.trim()).
+        This may cause some characters lost that passed by the flume.
+        Suppose we pass the record ("\007Foo\007Jack\007Shenzhen") with 4 fields delimited by '\007' and the first field is empty now, if we use the trim() here,
+        in the flume event body, we only can get 3 fields ("Foo\007Jack\007Shenzhen"), which should be not as expected.
+         */
+                Event event = EventBuilder.withBody(body, UTF_8, headers);
+
+                flumeManager.send(event);
+            } catch (Exception e) {
+                addError(e.getLocalizedMessage(), e);
+            }
+        }
+
     }
-    headers.put("thread", eventObject.getThreadName());
-    if (StringUtils.isNotEmpty(application)) {
-      headers.put("application", application);
+
+    private Map<String, String> extractHeaders(ILoggingEvent eventObject) {
+        Map<String, String> headers = new HashMap<String, String>(10);
+        headers.put("timestamp", Long.toString(eventObject.getTimeStamp()));
+        headers.put("type", eventObject.getLevel().toString());
+        headers.put("logger", eventObject.getLoggerName());
+        headers.put("message", eventObject.getMessage());
+        headers.put("level", eventObject.getLevel().toString());
+        try {
+            headers.put("host", resolveHostname());
+        } catch (UnknownHostException e) {
+            addWarn(e.getMessage());
+        }
+        headers.put("thread", eventObject.getThreadName());
+        if (StringUtils.isNotEmpty(application)) {
+            headers.put("application", application);
+        }
+
+        if (StringUtils.isNotEmpty(type)) {
+            headers.put("type", type);
+        }
+
+        return headers;
     }
 
-    if (StringUtils.isNotEmpty(type)) {
-      headers.put("type", type);
+    private String resolveHostname() throws UnknownHostException {
+        return hostname != null ? hostname : InetAddress.getLocalHost().getHostName();
     }
 
-    return headers;
-  }
-
-  private String resolveHostname() throws UnknownHostException {
-    return hostname != null ? hostname : InetAddress.getLocalHost().getHostName();
-  }
-
-  private String resolveApplication() {
-    return System.getProperty("application.name");
-  }
+    private String resolveApplication() {
+        return System.getProperty("application.name");
+    }
 }

--- a/src/main/java/com/gilt/logback/flume/FlumeLogstashV1Appender.java
+++ b/src/main/java/com/gilt/logback/flume/FlumeLogstashV1Appender.java
@@ -141,8 +141,8 @@ public class FlumeLogstashV1Appender extends UnsynchronizedAppenderBase<ILogging
             for (final String segment : segments) {
                 final String[] pair = segment.split("=");
                 if (pair.length == 2) {
-                    final String key = pair[0].trim();
-                    final String value = pair[1].trim();
+                    final String key = StringUtils.strip(pair[0]);
+                    final String value = StringUtils.strip(pair[1]);
                     if (StringUtils.isNotEmpty(key) && StringUtils.isNotEmpty(value)) {
                         props.put(key, value);
                     } else {
@@ -177,19 +177,11 @@ public class FlumeLogstashV1Appender extends UnsynchronizedAppenderBase<ILogging
             try {
                 String body = layout != null ? layout.doLayout(eventObject) : eventObject.getFormattedMessage();
                 Map<String, String> headers = new HashMap<String, String>();
-                if (additionalAvroHeaders != null) {
+                if(additionalAvroHeaders != null) {
                     headers.putAll(additionalAvroHeaders);
                 }
                 headers.putAll(extractHeaders(eventObject));
 
-
-                //Event event = EventBuilder.withBody(body.trim(), UTF_8, headers);
-        /*
-        FIX-01: trim() will cause the character that not greater than '\u0020' to be trimmed. Not only the whitespace(more details, refer the String.trim()).
-        This may cause some characters lost that passed by the flume.
-        Suppose we pass the record ("\007Foo\007Jack\007Shenzhen") with 4 fields delimited by '\007' and the first field is empty now, if we use the trim() here,
-        in the flume event body, we only can get 3 fields ("Foo\007Jack\007Shenzhen"), which should be not as expected.
-         */
                 Event event = EventBuilder.withBody(body, UTF_8, headers);
 
                 flumeManager.send(event);


### PR DESCRIPTION
Hi Arrieta,

We are using this code in our Flume system. But we found there are some issue as mentioned below:
 /*
        FIX-01: trim() will cause the character that not greater than '\u0020' to be trimmed. Not only the whitespace(more details, refer the String.trim()).
        This may cause some characters lost that passed by the flume.
        Suppose we pass the record ("\007Foo\007Jack\007Shenzhen") with 4 fields delimited by '\007' and the first field is empty now, if we use the trim() here,
        in the flume event body, we only can get 3 fields ("Foo\007Jack\007Shenzhen"), which should be not as expected.
         */
